### PR TITLE
EmVer update

### DIFF
--- a/EmVer/include/EmVer.hpp
+++ b/EmVer/include/EmVer.hpp
@@ -1,16 +1,19 @@
 #pragma once
 
-#include "TestSuite.hpp"
+#include <memory>
+
+#include "I_TestSuite.hpp"
 
 class I_EmVerWriter;
 
 class EmVer
 {
 public:
-    EmVer(const std::vector<TestSuite>& testSuites, I_EmVerWriter& writer);
+    EmVer(std::vector<std::shared_ptr<I_TestSuite>>& testSuites, I_EmVerWriter& writer);
     void start();
 
 private:
-    std::vector<TestSuite> testSuites_;
+    std::string indentMessage(const std::string& s);
+    std::vector<std::shared_ptr<I_TestSuite>> testSuites_;
     I_EmVerWriter& writer_;
 };

--- a/EmVer/include/EmVerWriter.hpp
+++ b/EmVer/include/EmVerWriter.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #include "mbed.h"
 
 #include "I_EmVerWriter.hpp"
@@ -8,11 +10,13 @@ class EmVerWriter : public I_EmVerWriter
 {
 public:
     EmVerWriter();
+    EmVerWriter(const EmVerWriter&) = delete;
+    EmVerWriter& operator=(const EmVerWriter&) = delete;
     ~EmVerWriter();
     void print(std::string msg);
     void println(std::string msg);
 
 private:
     FILE* fp_;
-    Serial* pc_;
+    std::unique_ptr<Serial> pc_;
 };

--- a/EmVer/include/I_TestSuite.hpp
+++ b/EmVer/include/I_TestSuite.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "TestCase.hpp"
+
+class I_TestSuite
+{
+public:
+    virtual ~I_TestSuite() {}
+    virtual int totalTestCases() const = 0;
+    virtual std::string name() const = 0;
+    virtual std::string testCaseName(unsigned int i) const = 0;
+    virtual std::string runTestCase(unsigned int i) const = 0;
+};

--- a/EmVer/include/TestSuite.hpp
+++ b/EmVer/include/TestSuite.hpp
@@ -3,16 +3,19 @@
 #include <string>
 #include <vector>
 
+#include "I_TestSuite.hpp"
 #include "TestCase.hpp"
 
-class TestSuite
+#include <iostream>
+
+class TestSuite : public I_TestSuite
 {
 public:
-	TestSuite(std::vector<TestCase*> testCases, std::string name);
-	int totalTestCases() const;
-	std::string name() const;
-	std::string testCaseName(unsigned int i) const;
-	std::string runTestCase(unsigned int i) const;
+    TestSuite(std::vector<TestCase*> testCases, std::string name);
+    int totalTestCases() const;
+    std::string name() const;
+    std::string testCaseName(unsigned int i) const;
+    std::string runTestCase(unsigned int i) const;
 
 protected:
     std::vector<TestCase*> testCases_;

--- a/EmVer/src/EmVer.cpp
+++ b/EmVer/src/EmVer.cpp
@@ -1,26 +1,73 @@
-#include "mbed.h"
+#include <memory>
+#include <sstream>
+#include <string>
 
 #include "EmVer.hpp"
 #include "I_EmVerWriter.hpp"
 
-EmVer::EmVer(const std::vector<TestSuite>& testSuites, I_EmVerWriter& writer)
+EmVer::EmVer(std::vector<std::shared_ptr<I_TestSuite>>& testSuites, I_EmVerWriter& writer)
 : testSuites_(testSuites)
 , writer_(writer)
 {}
 
 void EmVer::start()
 {
-    writer_.println("Beginning Tests...");
+    std::ostringstream summary;
+    int passedTestSuites = 0;
+
+    writer_.println("|===| EMVER START |===|");
     for(auto const& testSuite : testSuites_)
     {
-        writer_.println("Running TestSuite...");
-        for(int i = 0; i < testSuite.totalTestCases(); i++)
-        {
-            auto testCaseName = "Running test : " + testSuite.testCaseName(i) + "\n";
-            writer_.println(testCaseName);
+        writer_.println("Running Test Suite : " + testSuite->name());
+        int passedTestCases = 0;
 
-            auto testResults = testSuite.runTestCase(i);
-            writer_.println(testResults);
+        int totalTestCases = testSuite->totalTestCases();
+        for(int i = 0; i < totalTestCases; i++)
+        {
+            auto testCaseName = "> Running Test Case: " + testSuite->testCaseName(i);
+            writer_.print(testCaseName);
+
+            auto testResults = testSuite->runTestCase(i);
+            if(testResults.empty())
+            {
+                writer_.println(" [PASS]");
+                passedTestCases++;
+            }
+            else
+            {
+                writer_.println(" [FAIL]");
+                writer_.println(indentMessage(testResults));
+            }
         }
+        std::string testResult = "[FAIL]";
+        if (passedTestCases == totalTestCases)
+        {
+            testResult = "[PASS]";
+            passedTestSuites++;
+        }
+        summary << testResult << " " << testSuite->name() << " " << passedTestCases << "/" << totalTestCases << std::endl;
     }
+    writer_.println("\n|===| SUMMARY |===|");
+    writer_.println(summary.str());
+
+    std::ostringstream finalResult;
+    finalResult << passedTestSuites << "/" << testSuites_.size() << " Test Suites Passed";
+    writer_.println(finalResult.str());
+}
+
+std::string EmVer::indentMessage(const std::string& s) {
+   if (!s.size()) {
+     return "";
+   }
+   std::stringstream ss;
+   ss << "    ";
+   for (auto c : s)
+   {
+        ss << c;
+        if(c == '\n')
+        {
+            ss << "    ";
+        }
+   }
+   return ss.str();
 }

--- a/EmVer/src/EmVerWriter.cpp
+++ b/EmVer/src/EmVerWriter.cpp
@@ -13,7 +13,6 @@ EmVerWriter::EmVerWriter()
 EmVerWriter::~EmVerWriter()
 {
     fclose(fp_);
-    delete pc_;
 }
 
 void EmVerWriter::print(std::string msg)

--- a/EmVer/test/Makefile
+++ b/EmVer/test/Makefile
@@ -1,4 +1,4 @@
-OBJS = $(wildcard src/*.cpp) ../src/TestSuite.cpp
+OBJS = $(wildcard src/*.cpp) ../src/TestSuite.cpp ../src/EmVer.cpp
 
 COMPILE_FLAGS = -g -std=c++11 -Werror
 

--- a/EmVer/test/src/EmVerTest.cpp
+++ b/EmVer/test/src/EmVerTest.cpp
@@ -1,0 +1,113 @@
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "EmVer.hpp"
+#include "mocks/MockTestSuite.hpp"
+#include "mocks/MockEmVerWriter.hpp"
+
+using ::testing::_;
+using ::testing::Return;
+using ::testing::NiceMock;
+
+class EmVerTest : public ::testing::Test
+{
+protected:
+    MockEmVerWriter writer_;
+
+    virtual void SetUp()
+    {
+        writer_ = MockEmVerWriter();
+    }
+
+    virtual void TearDown()
+    {
+
+    }
+};
+
+TEST_F(EmVerTest, mixedTest)
+{
+    std::shared_ptr<NiceMock<MockTestSuite>> badSuite(new NiceMock<MockTestSuite>);
+    EXPECT_CALL(*badSuite, totalTestCases())
+        .WillRepeatedly(Return(2));
+    EXPECT_CALL(*badSuite, name())
+        .WillRepeatedly(Return("Bad Test Suite"));
+    EXPECT_CALL(*badSuite, testCaseName(0))
+        .WillRepeatedly(Return("Test Case 1"));
+    EXPECT_CALL(*badSuite, runTestCase(0))
+        .WillRepeatedly(Return(""));
+    EXPECT_CALL(*badSuite, testCaseName(1))
+        .WillRepeatedly(Return("Test Case 2"));
+    EXPECT_CALL(*badSuite, runTestCase(1))
+        .WillRepeatedly(Return("Failure Message"));
+
+    std::shared_ptr<NiceMock<MockTestSuite>> goodSuite(new NiceMock<MockTestSuite>);
+    EXPECT_CALL(*goodSuite, totalTestCases())
+        .WillRepeatedly(Return(2));
+    EXPECT_CALL(*goodSuite, name())
+        .WillRepeatedly(Return("Good Test Suite"));
+    EXPECT_CALL(*goodSuite, testCaseName(0))
+        .WillRepeatedly(Return("Test Case 3"));
+    EXPECT_CALL(*goodSuite, runTestCase(0))
+        .WillRepeatedly(Return(""));
+    EXPECT_CALL(*goodSuite, testCaseName(1))
+        .WillRepeatedly(Return("Test Case 4"));
+    EXPECT_CALL(*goodSuite, runTestCase(1))
+        .WillRepeatedly(Return(""));
+
+
+    std::vector<std::shared_ptr<I_TestSuite>> tests {badSuite, goodSuite};
+    EmVer e(tests, writer_);
+    e.start();
+
+    std::string expected =
+        "|===| EMVER START |===|\n"
+        "Running Test Suite : Bad Test Suite\n"
+        "> Running Test Case: Test Case 1 [PASS]\n"
+        "> Running Test Case: Test Case 2 [FAIL]\n"
+        "    Failure Message\n"
+        "Running Test Suite : Good Test Suite\n"
+        "> Running Test Case: Test Case 3 [PASS]\n"
+        "> Running Test Case: Test Case 4 [PASS]\n"
+        "\n"
+        "|===| SUMMARY |===|\n"
+        "[FAIL] Bad Test Suite 1/2\n"
+        "[PASS] Good Test Suite 2/2\n"
+        "\n"
+        "1/2 Test Suites Passed\n";
+    EXPECT_EQ(writer_.output(), expected);
+}
+
+TEST_F(EmVerTest, multiLineFailureMessage)
+{
+    std::shared_ptr<NiceMock<MockTestSuite>> badSuite(new NiceMock<MockTestSuite>);
+    EXPECT_CALL(*badSuite, totalTestCases())
+        .WillRepeatedly(Return(1));
+    EXPECT_CALL(*badSuite, name())
+        .WillRepeatedly(Return("Bad Test Suite"));
+    EXPECT_CALL(*badSuite, testCaseName(0))
+        .WillRepeatedly(Return("Test Case 1"));
+    EXPECT_CALL(*badSuite, runTestCase(0))
+        .WillRepeatedly(Return("Multi Line\nFailure"));
+
+    std::vector<std::shared_ptr<I_TestSuite>> tests {badSuite};
+    EmVer e(tests, writer_);
+    e.start();
+
+    std::string expected =
+        "|===| EMVER START |===|\n"
+        "Running Test Suite : Bad Test Suite\n"
+        "> Running Test Case: Test Case 1 [FAIL]\n"
+        "    Multi Line\n"
+        "    Failure\n"
+        "\n"
+        "|===| SUMMARY |===|\n"
+        "[FAIL] Bad Test Suite 0/1\n"
+        "\n"
+        "0/1 Test Suites Passed\n";
+    EXPECT_EQ(writer_.output(), expected);
+}

--- a/EmVer/test/src/mocks/MockEmVerWriter.hpp
+++ b/EmVer/test/src/mocks/MockEmVerWriter.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "I_EmVerWriter.hpp"
+
+class MockEmVerWriter : public I_EmVerWriter
+{
+public:
+    MockEmVerWriter()
+    : output_("")
+    {}
+
+    ~MockEmVerWriter() {}
+
+    void print(std::string msg)
+    {
+        output_ += msg;
+    }
+
+    void println(std::string msg)
+    {
+        output_ += msg + "\n";
+    }
+
+    std::string output()
+    {
+        return output_;
+    }
+
+private:
+    std::string output_;
+};

--- a/EmVer/test/src/mocks/MockTestSuite.hpp
+++ b/EmVer/test/src/mocks/MockTestSuite.hpp
@@ -1,0 +1,14 @@
+#include <string>
+
+#include <gmock/gmock.h>
+
+#include "I_TestSuite.hpp"
+
+class MockTestSuite : public I_TestSuite
+{
+public:
+    MOCK_CONST_METHOD0(totalTestCases, int());
+    MOCK_CONST_METHOD0(name, std::string());
+    MOCK_CONST_METHOD1(testCaseName, std::string(unsigned int));
+    MOCK_CONST_METHOD1(runTestCase, std::string(unsigned int));
+};

--- a/Example/Example.cpp
+++ b/Example/Example.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "EmVer.hpp"
 #include "EmVerWriter.hpp"
 #include "TestSuite.hpp"
@@ -9,10 +11,10 @@ int main()
 {
     ExampleTestA A;
     ExampleTestB B;
-    TestSuite exampleSuite({&A, &B}, "Example");
+    std::shared_ptr<TestSuite> exampleSuite(new TestSuite({&A, &B}, "Example"));
 
-    std::vector<TestSuite> tests {exampleSuite};
-    EmVerWriter writer = EmVerWriter();
+    std::vector<std::shared_ptr<I_TestSuite>> tests {exampleSuite};
+    EmVerWriter writer;
     EmVer e(tests, writer);
     e.start();
 }


### PR DESCRIPTION
- Add test for EmVer with bug fixes
- Use smart pointers
- Better indentation in output

Example output:

```
|===| EMVER START |===|
Running Test Suite : Bad Test Suite
> Running Test Case: Test Case 1 [PASS]
> Running Test Case: Test Case 2 [FAIL]
    Some Failure
    Message
Running Test Suite : Good Test Suite
> Running Test Case: Test Case 3 [PASS]
> Running Test Case: Test Case 4 [PASS]

|===| SUMMARY |===|
[FAIL] Bad Test Suite 1/2
[PASS] Good Test Suite 2/2

1/2 Test Suites Passed
```
